### PR TITLE
Add support for additional CoreOS units in user data

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,3 +142,4 @@ wimpy_app:
   environment: {}
   pre_commands: []
   post_commands: []
+  additional_units: []

--- a/templates/cloud_config.j2
+++ b/templates/cloud_config.j2
@@ -60,3 +60,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/home/core/install_docker_compose
+
+{% for unit in wimpy_app.additional_units %}
+    {{ unit }}
+{% endfor %}


### PR DESCRIPTION
Hello!
This change is to add support for additional CoreOS Units in user data part of cloud_config template https://github.com/fiunchinho/wimpy/blob/master/templates/cloud_config.j2

Here is an example on how to implement this change in your repos:

```
wimpy_app:
  environment: {}
  pre_commands: []
  post_commands: []
  additional_units:
    - |-
          name: install_docker_compose.service
          command: "start"
          content: |
            [Unit]
            Description=Install docker-compose
            After=docker.service
            Requires=docker.service

            [Service]
            Type=oneshot
            RemainAfterExit=true
            ExecStart=/home/core/install_docker_compose

    - |-
          name: install_docker_compose.service
          command: "start"
          content: |
            [Unit]
            Description=Install docker-compose
            After=docker.service
            Requires=docker.service

            [Service]
            Type=oneshot
            RemainAfterExit=true
            ExecStart=/home/core/install_docker_compose
```