### PR TITLE
A docker-compose template will be used if no docker-compose file is provided

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 wimpy_docker_compose_version: "1.11.1"
 wimpy_docker_compose_file: "{{ lookup('env','PWD') }}/docker-compose-{{ wimpy_deployment_environment }}.yml"
+wimpy_docker_compose_template: "templates/docker-compose.yml.j2"
 wimpy_deploy_strategy: "rolling_asg"
 wimpy_github_repository: ""
 wimpy_service_start_timeout: 500s

--- a/tasks/create_launchconfiguration.yml
+++ b/tasks/create_launchconfiguration.yml
@@ -1,5 +1,15 @@
 ---
 
+- stat:
+    path: "{{ wimpy_docker_compose_file }}"
+  register: wimpy_docker_compose_file_provided
+
+- name: "Render docker-compose file if none is provided"
+  template:
+    src: "{{ wimpy_docker_compose_template }}"
+    dest: "/tmp/docker-compose_{{ wimpy_deploy_id }}.yml"
+  when: not wimpy_docker_compose_file_provided.stat.exists
+
 - name: "Render cloud-config"
   template:
     src: "templates/cloud_config.j2"

--- a/templates/cloud_config.j2
+++ b/templates/cloud_config.j2
@@ -12,7 +12,11 @@ write_files:
     owner: core:core
     permissions: 0644
     content: |
+    {% if wimpy_docker_compose_file_provided.stat.exists %}
       {{ lookup('file', wimpy_docker_compose_file) | replace('image: ' + wimpy_docker_image_name, 'image: ' + wimpy_docker_image_name + ':' + wimpy_release_version) | indent(6, False) }}
+    {% else %}
+      {{ lookup('file', '/tmp/docker-compose_' ~ wimpy_deploy_id ~ '.yml') | indent(6, False) }}
+    {% endif %}
   - path: /home/core/healthcheck.sh
     owner: core:core
     permissions: 0744

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  {{ wimpy_project_name }}:
+    image: {{ wimpy_docker_image_name }}:{{ wimpy_release_version }}
+    ports:
+      - "{{ wimpy_app_port }}:{{ wimpy_app_port }}"


### PR DESCRIPTION
Wimpy uses per-environment docker-compose files to deploy applications, like `docker-compose-dev.yml` or `docker-compose-prod.yml`. These files are always really similar between environments and between applications.

With these changes, docker-compose files are not required. If the files are not provided, wimpy will use a template that will fit most of the use cases

```yaml
version: '2'
services:
  {{ wimpy_project_name }}:
    image: {{ wimpy_docker_image_name }}:{{ wimpy_release_version }}
    ports:
      - "{{ wimpy_app_port }}:{{ wimpy_app_port }}"
```

Applications can still create the docker-compose files as always, if they have special needs.

The docker-compose template used by Wimpy is also a variable. This means that organizations with several teams could provide their own template, for example, if they want to always run specific containers along with the application, like datadog for monitoring, sumologic for logging, or statsd for business metrics.