### PR TITLE
Avoid removing the cloudformation that we are deploying right now

### DIFF
--- a/tasks/remove_cloudformation.yml
+++ b/tasks/remove_cloudformation.yml
@@ -9,6 +9,7 @@
     stack_name: "{{ wimpy_previous_cf }}"
     all_facts: true
   register: wimpy_aws_cloudformation_facts
+  when: wimpy_previous_cf != wimpy_asg_name
 
 - name: "Delete ELB from DNS"
   route53:
@@ -23,11 +24,15 @@
     ttl: "{{ wimpy_aws_dns_ttl }}"
     type: "CNAME"
     value: "{{ wimpy_aws_cloudformation_facts['ansible_facts']['cloudformation'][wimpy_previous_cf]['stack_outputs']['LoadBalancer'] }}"
-  when: wimpy_aws_elb_enable
+  register: wimpy_disable_previous_elb_dns
+  when:
+    - wimpy_previous_cf != wimpy_asg_name
+    - wimpy_aws_elb_enable
 
 - name: "Waiting some seconds before removing previous CloudFormation"
   pause:
     seconds: "{{ wimpy_aws_dns_ttl * 2 }}"
+  when: wimpy_disable_previous_elb_dns.changed
 
 - name: "Remove previous CloudFormation"
   cloudformation:
@@ -35,3 +40,4 @@
     region: "{{ wimpy_aws_region }}"
     stack_name: "{{ wimpy_previous_cf }}"
     state: "absent"
+  when: wimpy_previous_cf != wimpy_asg_name


### PR DESCRIPTION
Wimpy finds the current CloudFormation before starting the deployment, so it can remove after the new CloudFormation has been deployed. But if you were deploying the same version twice, wimpy would update the current CloudFormation (since the name of the current CloudFormation is the same that you are deploying), to later remove it, leaving you without any CloudFormations alive.

This changes makes wimpy to skip removing the old CloudFormations with the same version that you are deploying.