### PR TITLE
fix/aws-docker-login: added --no-include-email in aws get-login operations

### DIFF
--- a/tasks/resolve_docker_login.yml
+++ b/tasks/resolve_docker_login.yml
@@ -2,7 +2,7 @@
 
 - name: Use aws ecr
   set_fact:
-    wimpy_docker_login: "/usr/bin/sh -c '/usr/bin/$(/usr/bin/docker run --rm xueshanf/awscli aws ecr get-login --region {{ wimpy_aws_region }})'"
+    wimpy_docker_login: "/usr/bin/sh -c '/usr/bin/$(/usr/bin/docker run --rm xueshanf/awscli aws ecr get-login --no-include-email --region {{ wimpy_aws_region }})'"
   when: wimpy_docker_image_name | search("ecr.{{ wimpy_aws_region }}.amazonaws.com/.+")
 
 - name: Use docker login


### PR DESCRIPTION
In order to fix a docker login issue in aws adding the "--no-include-email" to the docker get-login operation